### PR TITLE
add WNs 01 & 09 to ban list in django.yaml

### DIFF
--- a/npdbchart_sphenix/templates/django.yaml
+++ b/npdbchart_sphenix/templates/django.yaml
@@ -38,6 +38,8 @@ spec:
                 operator: NotIn
                 values:
                 - os-worker00.sdcc.bnl.gov
+                - os-worker01.sdcc.bnl.gov
+                - os-worker09.sdcc.bnl.gov
                 #- os-worker01.sdcc.bnl.gov
       #securityContext:
       #  fsGroup: 1000


### PR DESCRIPTION
pods on WNs 01 and 09 failed to initialize.