### PR TITLE
feat: add PgBouncer mappings for read replicas (R1/R2)

### DIFF
--- a/npdbchart_belle2_hsf/templates/pgbouncer.yaml
+++ b/npdbchart_belle2_hsf/templates/pgbouncer.yaml
@@ -26,6 +26,8 @@ data:
     [databases]
     pgbouncer = 
     {{ .Values.dbname_w }} = host={{ .Values.dbhost_w }} port=5432 dbname={{ .Values.dbname_w }}
+    {{ .Values.dbname_r1 }} = host={{ .Values.dbhost_r1 }} port=5432 dbname={{ .Values.dbname_r1 }}
+    {{ .Values.dbname_r2 }} = host={{ .Values.dbhost_r2 }} port=5432 dbname={{ .Values.dbname_r2 }}
     [pgbouncer]
     admin_users = {{ .Values.dbuser_w }}
     ignore_startup_parameters = extra_float_digits
@@ -44,6 +46,12 @@ data:
     reserve_pool_timeout = 5
   userlist.txt: |
     {{ .Values.dbuser_w | quote }} {{ .Values.dbpassword_w | quote }}
+    {{- if ne .Values.dbuser_r1 .Values.dbuser_w }}
+    {{ .Values.dbuser_r1 | quote }} {{ .Values.dbpassword_r1 | quote }}
+    {{- end }}
+    {{- if and (ne .Values.dbuser_r2 .Values.dbuser_w) (ne .Values.dbuser_r2 .Values.dbuser_r1) }}
+    {{ .Values.dbuser_r2 | quote }} {{ .Values.dbpassword_r2 | quote }}
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR extends the PgBouncer Helm chart configuration to support Django read-replica database routing by adding replica database mappings for `POSTGRES_DB_R1` and `POSTGRES_DB_R2` in the `pgbouncer.ini` `[databases]` section.

It also updates `userlist.txt` generation to conditionally include replica user credentials while avoiding duplicate entries when the same credentials are shared across write and read connections.

This completes the PgBouncer-side configuration required for Django’s existing read/write database routing to correctly forward read traffic through PgBouncer, without introducing application code or schema changes.