### PR TITLE
feat: add PostgreSQL replica StatefulSet with pg_basebackup

### DIFF
--- a/openshift/statefulset_psql_replica.yaml
+++ b/openshift/statefulset_psql_replica.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: b2testpsql-replica-headless
+  namespace: belle2-cdb
+spec:
+  clusterIP: None
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  selector:
+    app: b2testpsql-replica
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: b2testpsql-replica
+  namespace: belle2-cdb
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  selector:
+    app: b2testpsql-replica
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: b2testpsql-replica
+  namespace: belle2-cdb
+spec:
+  serviceName: b2testpsql-replica-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: b2testpsql-replica
+  template:
+    metadata:
+      labels:
+        app: b2testpsql-replica
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: seed-from-primary
+          image: registry.redhat.io/rhel9/postgresql-15
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              if [ -s /var/lib/pgsql/data/PG_VERSION ]; then
+                exit 0
+              fi
+              rm -rf /var/lib/pgsql/data/*
+              PGPASSWORD="${POSTGRESQL_PASSWORD}" pg_basebackup \
+                -h b2testpsql-primary.belle2-cdb.svc.cluster.local \
+                -U "${POSTGRESQL_USER}" \
+                -D /var/lib/pgsql/data \
+                --wal-method=stream \
+                --checkpoint=fast
+              touch /var/lib/pgsql/data/standby.signal
+              chmod 700 /var/lib/pgsql/data
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: b2testpsql-credentials
+                  key: username
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: b2testpsql-credentials
+                  key: password
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+      containers:
+        - name: postgres
+          image: registry.redhat.io/rhel9/postgresql-15
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRESQL_DATABASE
+              value: conditions
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: b2testpsql-credentials
+                  key: username
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: b2testpsql-credentials
+                  key: password
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/pgsql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi

--- a/openshift/statefulset_psql_replica.yaml
+++ b/openshift/statefulset_psql_replica.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: b2testpsql-replica-headless
-  namespace: belle2-cdb
+  namespace: ${NAMESPACE}
 spec:
   clusterIP: None
   ports:
@@ -19,7 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: b2testpsql-replica
-  namespace: belle2-cdb
+  namespace: ${NAMESPACE}
   labels:
     metrics-target: postgres
     postgres-role: replica
@@ -38,7 +38,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: b2testpsql-replica
-  namespace: belle2-cdb
+  namespace: ${NAMESPACE}
 spec:
   serviceName: b2testpsql-replica-headless
   replicas: 1
@@ -54,6 +54,12 @@ spec:
         runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: postgres-logs
+          emptyDir: {}
+        - name: promtail-config
+          configMap:
+            name: promtail-config
       initContainers:
         - name: seed-from-primary
           image: postgres:15
@@ -66,7 +72,7 @@ spec:
               fi
               rm -rf /var/lib/pgsql/data/*
               PGPASSWORD="${POSTGRESQL_PASSWORD}" pg_basebackup \
-                -h b2testpsql-primary.belle2-cdb.svc.cluster.local \
+                -h b2testpsql-primary.${NAMESPACE}.svc.cluster.local \
                 -U "${POSTGRESQL_USER}" \
                 -D /var/lib/pgsql/data \
                 --wal-method=stream \
@@ -90,6 +96,15 @@ spec:
       containers:
         - name: postgres
           image: postgres:15
+          args:
+            - "-c"
+            - "log_min_duration_statement=500"
+            - "-c"
+            - "logging_collector=on"
+            - "-c"
+            - "log_directory=/var/log/postgresql"
+            - "-c"
+            - "log_filename=postgresql-%Y-%m-%d.log"
           ports:
             - containerPort: 5432
               name: postgres
@@ -116,6 +131,8 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data
+            - name: postgres-logs
+              mountPath: /var/log/postgresql
         - name: postgres-exporter
           image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
           ports:
@@ -127,6 +144,15 @@ spec:
                 secretKeyRef:
                   name: b2testpsql-exporter-dsn
                   key: dsn
+        - name: promtail
+          image: grafana/promtail:2.9.0
+          args:
+            - "-config.file=/etc/promtail/promtail-config.yaml"
+          volumeMounts:
+            - name: postgres-logs
+              mountPath: /var/log/postgresql
+            - name: promtail-config
+              mountPath: /etc/promtail
   volumeClaimTemplates:
     - metadata:
         name: postgres-data

--- a/openshift/statefulset_psql_replica.yaml
+++ b/openshift/statefulset_psql_replica.yaml
@@ -9,6 +9,9 @@ spec:
     - port: 5432
       targetPort: 5432
       name: postgres
+    - port: 9187
+      targetPort: 9187
+      name: metrics
   selector:
     app: b2testpsql-replica
 ---
@@ -17,11 +20,17 @@ kind: Service
 metadata:
   name: b2testpsql-replica
   namespace: belle2-cdb
+  labels:
+    metrics-target: postgres
+    postgres-role: replica
 spec:
   ports:
     - port: 5432
       targetPort: 5432
       name: postgres
+    - port: 9187
+      targetPort: 9187
+      name: metrics
   selector:
     app: b2testpsql-replica
 ---
@@ -42,12 +51,12 @@ spec:
         app: b2testpsql-replica
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       initContainers:
         - name: seed-from-primary
-          image: registry.redhat.io/rhel9/postgresql-15
+          image: postgres:15
           command:
             - /bin/bash
             - -ec
@@ -80,7 +89,7 @@ spec:
               mountPath: /var/lib/pgsql/data
       containers:
         - name: postgres
-          image: registry.redhat.io/rhel9/postgresql-15
+          image: postgres:15
           ports:
             - containerPort: 5432
               name: postgres
@@ -107,6 +116,17 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data
+        - name: postgres-exporter
+          image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+          ports:
+            - containerPort: 9187
+              name: metrics
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: b2testpsql-exporter-dsn
+                  key: dsn
   volumeClaimTemplates:
     - metadata:
         name: postgres-data


### PR DESCRIPTION
## Description

This PR adds a PostgreSQL replica deployment based on a StatefulSet, along with the required headless and client-facing services. The replica is initialized from the primary database using `pg_basebackup` and configured to run in standby mode through the creation of a `standby.signal` file.

This setup provides stable pod identities, persistent storage, and a foundation for primary/replica database topology on OpenShift.

Enable PostgreSQL file-based logging and add a Promtail sidecar to collect database logs from replica pods. Also standardize namespace references and fix the replica basebackup host configuration.

## Notes

* Database credentials are sourced from the `b2testpsql-credentials` Secret (`openshift/secret_psql_credentials.yaml`) and are not hardcoded in the manifests.
* Primary and replica service hostnames are currently defined explicitly in the OpenShift manifests. These values can be parameterized and Helm-templated in a follow-up PR to improve portability and reusability.
