### PR TITLE
feat:  move PostgreSQL credentials to Kubernetes Secret for primary and replica

### DIFF
--- a/openshift/secret_psql_credentials.yaml
+++ b/openshift/secret_psql_credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: b2testpsql-credentials
+  namespace: belle2-cdb
+type: Opaque
+stringData:
+  username: dbuser
+  password: dbpassword


### PR DESCRIPTION
Hardcoding DB credentials in manifests is not secure and is unsuitable for shared/staging/production environments. Using secretKeyRef aligns with Kubernetes/OpenShift security best practices and keeps sensitive data out of workload specs.