### PR TITLE
Switch OpenShift PostgreSQL to official postgres:15.9 image 

### DIFF
--- a/openshift/deployment_psql_client.yaml
+++ b/openshift/deployment_psql_client.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sql-client
-  namespace: belle2-cdb
+  namespace: ${NAMESPACE}
 spec:
   replicas: 1
   selector:

--- a/openshift/deployment_psql_server.yaml
+++ b/openshift/deployment_psql_server.yaml
@@ -61,7 +61,7 @@ spec:
         app: b2testpsql-primary
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       volumes:
@@ -72,7 +72,28 @@ spec:
             name: promtail-config
       containers:
         - name: ${INSTANCE_NAME}
-          image: registry.redhat.io/rhel9/postgresql-15
+          image: postgres:15.9
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - |
+                    set +e
+                    HBA_FILE=/var/lib/postgresql/data/pg_hba.conf
+                    if [ -f "$HBA_FILE" ]; then
+                      grep -Eq '^host[[:space:]]+replication[[:space:]]+all[[:space:]]+0\.0\.0\.0/0[[:space:]]+scram-sha-256$' "$HBA_FILE" || \
+                        echo 'host replication all 0.0.0.0/0 scram-sha-256' >> "$HBA_FILE"
+                      grep -Eq '^host[[:space:]]+replication[[:space:]]+all[[:space:]]+::/0[[:space:]]+scram-sha-256$' "$HBA_FILE" || \
+                        echo 'host replication all ::/0 scram-sha-256' >> "$HBA_FILE"
+                      if [ -s /var/lib/postgresql/data/postmaster.pid ]; then
+                        PID=$(head -n1 /var/lib/postgresql/data/postmaster.pid)
+                        kill -HUP "$PID" 2>/dev/null
+                      fi
+                    fi
+
+                    exit 0
           args:
             - "-c"
             - "shared_preload_libraries=pg_stat_statements"
@@ -90,14 +111,14 @@ spec:
             - containerPort: 5432
               name: postgres
           env:
-            - name: POSTGRESQL_DATABASE
+            - name: POSTGRES_DB
               value: "${POSTGRESQL_DATABASE}"
-            - name: POSTGRESQL_USER
+            - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
                   key: username
-            - name: POSTGRESQL_PASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
@@ -111,7 +132,7 @@ spec:
               memory: "8Gi"
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/pgsql/data
+              mountPath: /var/lib/postgresql/data
             - name: postgres-logs
               mountPath: /var/log/postgresql
         - name: postgres-exporter

--- a/openshift/secret_psql_credentials.yaml
+++ b/openshift/secret_psql_credentials.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: b2testpsql-credentials
-  namespace: belle2-cdb
+  namespace: ${NAMESPACE}
 type: Opaque
 stringData:
   username: dbuser

--- a/openshift/statefulset_psql_replica.yaml
+++ b/openshift/statefulset_psql_replica.yaml
@@ -67,32 +67,33 @@ spec:
             - /bin/bash
             - -ec
             - |
-              if [ -s /var/lib/pgsql/data/PG_VERSION ]; then
+              if [ -s /var/lib/postgresql/data/PG_VERSION ]; then
                 exit 0
               fi
-              rm -rf /var/lib/pgsql/data/*
-              PGPASSWORD="${POSTGRESQL_PASSWORD}" pg_basebackup \
+              rm -rf /var/lib/postgresql/data/*
+              PGPASSWORD="${POSTGRES_PASSWORD}" pg_basebackup \
                 -h b2testpsql-primary.${NAMESPACE}.svc.cluster.local \
-                -U "${POSTGRESQL_USER}" \
-                -D /var/lib/pgsql/data \
+                -U "${POSTGRES_USER}" \
+                -D /var/lib/postgresql/data \
                 --wal-method=stream \
                 --checkpoint=fast
-              touch /var/lib/pgsql/data/standby.signal
-              chmod 700 /var/lib/pgsql/data
+
+              touch /var/lib/postgresql/data/standby.signal
+              chmod 700 /var/lib/postgresql/data
           env:
-            - name: POSTGRESQL_USER
+            - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
                   key: username
-            - name: POSTGRESQL_PASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
                   key: password
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/pgsql/data
+              mountPath: /var/lib/postgresql/data
       containers:
         - name: postgres
           image: postgres:15
@@ -109,14 +110,14 @@ spec:
             - containerPort: 5432
               name: postgres
           env:
-            - name: POSTGRESQL_DATABASE
+            - name: POSTGRES_DB
               value: conditions
-            - name: POSTGRESQL_USER
+            - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
                   key: username
-            - name: POSTGRESQL_PASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
@@ -130,7 +131,7 @@ spec:
               memory: "8Gi"
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/pgsql/data
+              mountPath: /var/lib/postgresql/data
             - name: postgres-logs
               mountPath: /var/log/postgresql
         - name: postgres-exporter


### PR DESCRIPTION
### Description

This migrates the OpenShift PostgreSQL primary and replica manifests from the Red Hat S2I image (`registry.redhat.io/rhel9/postgresql-15`) to the official upstream `postgres` image, and aligns configuration with upstream conventions.
