### PR TITLE
fix(postgres): make primary postStart hook wait for pg_hba.conf and reliably enable replication access

### DIFF
--- a/openshift/deployment_psql_server.yaml
+++ b/openshift/deployment_psql_server.yaml
@@ -61,7 +61,7 @@ spec:
         app: b2testpsql-primary
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       volumes:
@@ -72,7 +72,32 @@ spec:
             name: promtail-config
       containers:
         - name: ${INSTANCE_NAME}
-          image: registry.redhat.io/rhel9/postgresql-15
+          image: postgres:15.9
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - |
+                    set +e
+                    HBA_FILE=/var/lib/postgresql/data/pg_hba.conf
+                    for i in $(seq 1 30); do
+                      [ -f "$HBA_FILE" ] && break
+                      sleep 1
+                    done
+                    if [ -f "$HBA_FILE" ]; then
+                      grep -Eq '^host[[:space:]]+replication[[:space:]]+all[[:space:]]+0\.0\.0\.0/0[[:space:]]+scram-sha-256$' "$HBA_FILE" || \
+                        echo 'host replication all 0.0.0.0/0 scram-sha-256' >> "$HBA_FILE"
+                      grep -Eq '^host[[:space:]]+replication[[:space:]]+all[[:space:]]+::/0[[:space:]]+scram-sha-256$' "$HBA_FILE" || \
+                        echo 'host replication all ::/0 scram-sha-256' >> "$HBA_FILE"
+                      if [ -s /var/lib/postgresql/data/postmaster.pid ]; then
+                        PID=$(head -n1 /var/lib/postgresql/data/postmaster.pid)
+                        kill -HUP "$PID" 2>/dev/null
+                      fi
+                    fi
+
+                    exit 0
           args:
             - "-c"
             - "shared_preload_libraries=pg_stat_statements"
@@ -90,14 +115,14 @@ spec:
             - containerPort: 5432
               name: postgres
           env:
-            - name: POSTGRESQL_DATABASE
+            - name: POSTGRES_DB
               value: "${POSTGRESQL_DATABASE}"
-            - name: POSTGRESQL_USER
+            - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
                   key: username
-            - name: POSTGRESQL_PASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: b2testpsql-credentials
@@ -111,7 +136,7 @@ spec:
               memory: "8Gi"
           volumeMounts:
             - name: postgres-data
-              mountPath: /var/lib/pgsql/data
+              mountPath: /var/lib/postgresql/data
             - name: postgres-logs
               mountPath: /var/log/postgresql
         - name: postgres-exporter


### PR DESCRIPTION
### Description

This improves the reliability of PostgreSQL replica initialization by making the primary StatefulSet's `postStart` hook more resilient to startup timing. Previously, the hook assumed that `pg_hba.conf` was already present when it ran. In some cases, however, the file had not yet been created, which caused the replication configuration step to be skipped.

To address this, the `postStart` hook now waits for up to 30 seconds for `pg_hba.conf` to become available before applying any changes. Once the file exists, it safely ensures that the required replication host rules are present for both IPv4 (`0.0.0.0/0`) and IPv6 (`::/0`) using `scram-sha-256`. The update is idempotent, so existing entries are not duplicated. After the configuration is modified, the hook sends a `SIGHUP` signal to the running PostgreSQL process, when available, allowing PostgreSQL to reload the updated configuration without requiring a restart.

These changes fix an intermittent issue where replica initialization would fail because `pg_basebackup` could not establish a replication connection, reporting a `no pg_hba.conf entry for replication connection` error. The root cause was a startup race condition in which the hook executed before `pg_hba.conf` had been generated. By waiting for the file and reloading the configuration after updating it, the replication bootstrap process becomes much more reliable.
